### PR TITLE
scripts/quickstart: Fix passing -d DOMAIN to scripts/make-env

### DIFF
--- a/scripts/make-env
+++ b/scripts/make-env
@@ -17,7 +17,8 @@ usage() {
 
 for var in DOMAIN DB_USER DB_PASSWORD DB_PORT HOST_MODE VERSION JWT_SECRET; do
   if [ -z "${!var-}" ]; then
-    usage
+    echo "Error: variable $var is not set, aborting!" >&2
+    usage >&2
     exit 1
   fi
 done

--- a/scripts/quickstart
+++ b/scripts/quickstart
@@ -27,7 +27,7 @@ usage() {
 }
 
 show_help=false
-while getopts ":hxdUPpi:v:j:" opt; do
+while getopts ":hxd:UPpi:v:j:" opt; do
   case "${opt}" in
     h) show_help=true;;
     x) set -x;;
@@ -65,7 +65,11 @@ echo_bold "==> Creating new configuration at: $CONFIG_DIR"
 mkdir -p "$CONFIG_DIR"
 
 echo_bold "==> Setting up environment..."
-cat >"${CONFIG_DIR}/activate" <(source "${DIR}/make-env")
+if cat >"${CONFIG_DIR}/activate.out" <(source "${DIR}/make-env"); then
+    mv "${CONFIG_DIR}/activate.out" "${CONFIG_DIR}/activate"
+else
+    exit 1
+fi
 
 echo_bold "==> Adding default compose file..."
 cp "${BASE_DIR}/compose/template.yml" "${CONFIG_DIR}/docker-compose.yml"


### PR DESCRIPTION
Fix `getopts` so that `scripts/quickstart -d` takes the `DOMAIN` argument:

Without it, `d) DOMAIN="${OPTARG}"` is empty and `make-env` aborts because `DOMAIN` is empty.

Update `make-env` to write this error to `stderr` so it can be seen on the shell (`scripts/quickstart` redirects its stdout to a file).

Also check the return value `make-env` and only overwrite the config in `${CONFIG_DIR}/activate` when make-env didn't return an error.

This fixes the documented use of `quickstart -d yourdomain.org` to set the domain and succeed to generate a configuration.