### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If you are installing on the same host as open-balena, you can use these command
 ```sh
 source open-balena/config/activate ; source open-balena/compose/versions
 open-balena-admin/scripts/quickstart -j $OPENBALENA_JWT_SECRET \
-	-v $OPENBALENA_API_VERSION_TAG -d $OPENBALENA_HOST_NAME
+	-v $OPENBALENA_API_VERSION_TAG -d $OPENBALENA_HOST_NAME -a $OPENBALENA_S3_ACCESS_KEY -s $OPENBALENA_S3_SECRET_KEY
 ```
 
 **Note**: If you did not complete steps 1 and 2 (i.e. you have a running instance of openbalena) you need to ssh into your running instance of open-balena-api, where you will find `OPENBALENA_JWT_SECRET` via the environment variable `JSON_WEB_TOKEN_SECRET`, and `OPENBALENA_API_VERSION` as "version" within `/usr/src/app/package.json`


### PR DESCRIPTION
Greetings,
As of today, January 12, 2024 If one follows the instruction, they will encounter an error on the quickstart script where it will keep showing the help and exiting. I looked into the code for the quickstart  code and it seems it requires S3_ACCESS_KEY and S3_SECRET_KEY so I have just added them to the command using their respective option and env